### PR TITLE
ボタンタップでカードスワイプすると、サブテキストが消えない問題の修正

### DIFF
--- a/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnit.storyboard
+++ b/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnit.storyboard
@@ -128,7 +128,7 @@
         <image name="check_mark_icon" width="56" height="56"/>
         <image name="close_icon" width="50" height="50"/>
         <namedColor name="MainBlue">
-            <color red="0.10980392156862745" green="0.6705882352941176" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.027450980392156862" green="0.72941176470588232" blue="0.99607843137254903" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="WeakText">
             <color red="0.67100000381469727" green="0.67100000381469727" blue="0.67100000381469727" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
+++ b/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
@@ -76,11 +76,13 @@ class LearningUnitViewController: UIViewController {
         // 覚えたボタンタップ
         memorizedButton.rx.tap.subscribe(onNext: { [weak self] in
             self?.kolodaView.swipe(.right)
+            self?.cardSwipingSubject.onNext(())
         }).disposed(by: disposebag)
 
         // 覚えていないボタンタップ
         notMemorizedButton.rx.tap.subscribe(onNext: { [weak self] in
             self?.kolodaView.swipe(.left)
+            self?.cardSwipingSubject.onNext(())
         }).disposed(by: disposebag)
     }
 
@@ -104,12 +106,12 @@ extension LearningUnitViewController: KolodaViewDelegate {
 
     /// カードがタップされた際に呼ばれるメソッド
     func koloda(_ koloda: KolodaView, didSelectCardAt index: Int) {
-        self.cardTappedSubject.onNext(())
+        cardTappedSubject.onNext(())
     }
 
     /// カードのスワイプ中に呼ばれるメソッド
     func koloda(_ koloda: KolodaView, shouldDragCardAt index: Int) -> Bool {
-        self.cardSwipingSubject.onNext(())
+        cardSwipingSubject.onNext(())
         return true
     }
 


### PR DESCRIPTION
# Related issues(関連issues)
close #57 

# Overview(概要)
表題のとおり

# Check result(確認項目)
- [x] サブテキストを表示した状態で、ボタンタップによるカードスワイプをした場合、サブテキストが非表示になる
