### PR TITLE
苦手の数が0の場合にアラートを表示する

### DIFF
--- a/Japanese_nursing/src/Views/Test/TestSettingsViewController.swift
+++ b/Japanese_nursing/src/Views/Test/TestSettingsViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import Charts
 import RxSwift
 import RxCocoa
+import PKHUD
 
 /**
  * テスト設定画面VC
@@ -124,7 +125,11 @@ extension TestSettingsViewController {
 
         // 苦手ボタンタップ
         mistakeButton.rx.tap.subscribe(onNext: { [weak self] in
-            // TODO: 苦手数が0の場合にアラートを表示する処理を追加する
+            // 苦手数が0の場合はアラートを表示してreturn
+            if self?.mistakeCount == 0 {
+                HUD.flash(.label("苦手な単語はありません"), delay: 1.0)
+                return
+            }
             self?.updateSelectingQuestionRange(tappedType: .mistake)
         }).disposed(by: disposeBag)
 


### PR DESCRIPTION
# Related issues(関連issues)
close #66 

# Overview(概要)
苦手の数が0の場合、ボタンタップでアラートを表示するよう実装した。

# Notes(備考)
<img width="300" alt="スクリーンショット 2020-11-08 13 15 48" src="https://user-images.githubusercontent.com/43531196/98456841-f6a13a00-21c4-11eb-9dbe-d6ca54a2980b.png">
