### PR TITLE
学習終了モーダルの実装

### DIFF
--- a/Japanese_nursing/Colors.xcassets/TextBlue.colorset/Contents.json
+++ b/Japanese_nursing/Colors.xcassets/TextBlue.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x24",
+          "red" : "0x0D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.502",
+          "green" : "0.141",
+          "red" : "0.051"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.502",
+          "green" : "0.141",
+          "red" : "0.051"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Japanese_nursing/Colors.xcassets/WeakSubText.colorset/Contents.json
+++ b/Japanese_nursing/Colors.xcassets/WeakSubText.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "92",
+          "green" : "92",
+          "red" : "92"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.361",
+          "green" : "0.361",
+          "red" : "0.361"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.361",
+          "green" : "0.361",
+          "red" : "0.361"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Japanese_nursing/Colors.xcassets/WeakTextBlue.colorset/Contents.json
+++ b/Japanese_nursing/Colors.xcassets/WeakTextBlue.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA5",
+          "green" : "0x64",
+          "red" : "0x55"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.647",
+          "green" : "0.392",
+          "red" : "0.333"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.647",
+          "green" : "0.392",
+          "red" : "0.333"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
+++ b/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
@@ -135,12 +135,14 @@ extension LearningUnitViewController: KolodaViewDelegate {
                 showCloseButton: false, titleColor: R.color.textBlue()!
             )
             let alertView = SCLAlertView(appearance: appearance)
-            alertView.addButton("もう一度学習する") {
-                self.kolodaView.resetCurrentCardIndex()
-                self.updateProgressView(swipedCardIndex: -1)
+            alertView.addButton("もう一度学習する") { [weak self] in
+                // カードをもう一度表示する
+                self?.kolodaView.resetCurrentCardIndex()
+                // プログレスバーを初期化する
+                self?.progressView.setProgress(0, animated: true)
             }
-            alertView.addButton("終了する") {
-                self.dismiss(animated: true)
+            alertView.addButton("終了する") { [weak self] in
+                self?.dismiss(animated: true)
             }
 
             alertView.showTitle("学習が終了しました！",

--- a/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
+++ b/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import Koloda
 import RxSwift
 import RxCocoa
+import SCLAlertView
 
 /**
  * 学習画面VC
@@ -125,6 +126,33 @@ extension LearningUnitViewController: KolodaViewDelegate {
 //            break
 //        }
         updateProgressView(swipedCardIndex: index)
+
+        // 最後のカードがスワイプされたらモーダルを表示する
+        if index + 1 >= items.count {
+            let appearance = SCLAlertView.SCLAppearance(
+                kTitleFont: R.font.notoSansCJKjpSubBold(size: 16)!,
+                kTextFont: R.font.notoSansCJKjpSubMedium(size: 12)!,
+                showCloseButton: false, titleColor: R.color.textBlue()!
+            )
+            let alertView = SCLAlertView(appearance: appearance)
+            alertView.addButton("もう一度学習する") {
+                self.kolodaView.resetCurrentCardIndex()
+                self.updateProgressView(swipedCardIndex: -1)
+            }
+            alertView.addButton("終了する") {
+                self.dismiss(animated: true)
+            }
+
+            alertView.showTitle("学習が終了しました！",
+                                subTitle: "もう一度学習しますか？",
+                                timeout: nil,
+                                completeText: "",
+                                style: .success,
+                                colorStyle: 0x07BAFE,
+                                colorTextButton: nil,
+                                circleIconImage: nil,
+                                animationStyle: .bottomToTop)
+        }
     }
 
 }


### PR DESCRIPTION
# Related issues(関連issues)
close #69 

# Overview(概要)
表題のとおり

## Details(詳細)
- [x] [SCLAlertView](https://github.com/vikmeup/SCLAlertView-Swift)を使用

# Check result(確認項目)
- [x] 最後のカードをスワイプしたらモーダルが表示される
- [x] 「もう一度学習する」をタップすると、カードがもう一度表示され、プログレスバーが初期化される
- [x] 「終了する」をタップすると、モーダルと学習画面が閉じ、単元一覧画面に戻る

# Notes(備考)
<img width="300" alt="スクリーンショット 2020-11-09 0 49 07" src="https://user-images.githubusercontent.com/43531196/98469968-f6855680-2225-11eb-83e1-9671c69fc367.png">

