### PR TITLE
目標設定まわりの値の反映処理を追加

### DIFF
--- a/Japanese_nursing/src/ViewModels/Mypage/MypageViewModel.swift
+++ b/Japanese_nursing/src/ViewModels/Mypage/MypageViewModel.swift
@@ -60,6 +60,10 @@ class MypageViewModel {
                 return activity.activities.map(ActivitiesDomainModel.init)
             }
             .do(onNext: { [unowned self] in
+                // 初期化
+                activities = []
+                activityCountArray = []
+                dateArray = []
                 activities.append(contentsOf: $0)
                 addActivity(activities: activities)
             })

--- a/Japanese_nursing/src/Views/Mypage/MyPageViewController.swift
+++ b/Japanese_nursing/src/Views/Mypage/MyPageViewController.swift
@@ -150,7 +150,6 @@ extension MyPageViewController: UIAdaptivePresentationControllerDelegate {
             .subscribe(
                 onNext: { [unowned self] status in
                     isGettedTargetStatus = true
-                    print("gett")
 
                     targetLearningCount = status.targetLearningCount
                     todayLearnedCount = status.todayLearnedCount
@@ -172,7 +171,6 @@ extension MyPageViewController: UIAdaptivePresentationControllerDelegate {
             .subscribe(
                 onNext: { [unowned self] status in
                     isGettedActivities = true
-                    print("geta")
 
                     if isGettedTargetStatus && isGettedActivities {
                         setupCharts(animate: animate)

--- a/Japanese_nursing/src/Views/Mypage/MyPageViewController.swift
+++ b/Japanese_nursing/src/Views/Mypage/MyPageViewController.swift
@@ -50,8 +50,8 @@ class MyPageViewController: UIViewController {
         let v = R.nib.emptyView.firstView(owner: nil)!
         v.backgroundColor = R.color.mypage()
         v.retryAction = { [weak self] in
-            self?.fetchTargetStatus()
-            self?.fetchActivities()
+            self?.fetchTargetStatus(animate: true)
+            self?.fetchActivities(animate: true)
         }
         v.page = .learn
         v.status = .none
@@ -69,6 +69,12 @@ class MyPageViewController: UIViewController {
     // アクティビティ
     private var activityCountArray:[Int] = []
 
+    /// 目標達成状況を取得済か
+    private var isGettedTargetStatus: Bool = false
+
+    /// アクティビティを取得済か
+    private var isGettedActivities: Bool = false
+
     // MARK: - LifeCycles
 
     override func viewDidLoad() {
@@ -76,8 +82,8 @@ class MyPageViewController: UIViewController {
 
         navigationController?.setNavigationBarHidden(true, animated: true)
 
-        fetchTargetStatus()
-        fetchActivities()
+        fetchTargetStatus(animate: true)
+        fetchActivities(animate: true)
 
         subscribe()
     }
@@ -89,38 +95,49 @@ class MyPageViewController: UIViewController {
         barChartAnimation()
     }
 
+    // 遷移先の画面が閉じられた時に呼ばれる
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        print("hohoho")
+        fetchTargetStatus(animate: false)
+        fetchActivities(animate: false)
+    }
+
 }
 
 // MARK: - Functions
 
-extension MyPageViewController {
+extension MyPageViewController: UIAdaptivePresentationControllerDelegate {
 
     private func subscribe() {
         // 学習円形進捗バーボタンタップ
-        studyPieChartButton.rx.tap.subscribe(onNext: { [weak self] in
-            let vc = TargetSettingViewController.makeInstance(targetType: .study)
-            self?.present(vc, animated: true)
+        studyPieChartButton.rx.tap.subscribe(onNext: { [unowned self] in
+            let vc = TargetSettingViewController.makeInstance(targetType: .study, initialTargetCount: targetLearningCount)
+            vc.presentationController?.delegate = self
+            present(vc, animated: true)
+
         }).disposed(by: disposeBag)
 
         // テスト円形進捗バーボタンタップ
-        testPieChartButton.rx.tap.subscribe(onNext: { [weak self] in
-            let vc = TargetSettingViewController.makeInstance(targetType: .test)
-            self?.present(vc, animated: true)
+        testPieChartButton.rx.tap.subscribe(onNext: { [unowned self] in
+            let vc = TargetSettingViewController.makeInstance(targetType: .test, initialTargetCount: targetTestingCount)
+            vc.presentationController?.delegate = self
+            present(vc, animated: true)
         }).disposed(by: disposeBag)
 
         // 設定ボタンタップ
-        settingButton.rx.tap.subscribe(onNext: { [weak self] in
-            let vc = SettingListViewController.makeInstanceInNavigationController()
-            self?.present(vc, animated: true)
+        settingButton.rx.tap.subscribe(onNext: { [unowned self] in
+            let vc = SettingListViewController.makeInstanceInNavigationController(targetLearningCount: targetLearningCount, targetTestingCount: targetTestingCount)
+            vc.presentationController?.delegate = self
+            present(vc, animated: true)
         }).disposed(by: disposeBag)
 
         // loading
         viewModel.loadingDriver
-            .map { isLoading in
-                if isLoading {
-                    return .loading
-                } else {
+            .map { [unowned self] isLoading in
+                if isGettedActivities && isGettedTargetStatus {
                     return .none
+                } else {
+                    return .loading
                 }
             }
             .drive(onNext: {[weak self] in
@@ -128,19 +145,21 @@ extension MyPageViewController {
             }).disposed(by: disposeBag)
     }
 
-    private func fetchTargetStatus() {
+    private func fetchTargetStatus(animate: Bool) {
         viewModel.fetchTargetStatus(authToken: ApplicationConfigData.authToken)
             .subscribe(
                 onNext: { [unowned self] status in
+                    isGettedTargetStatus = true
+                    print("gett")
+
                     targetLearningCount = status.targetLearningCount
                     todayLearnedCount = status.todayLearnedCount
                     targetTestingCount = status.targetTestingCount
                     todayTestedCount = status.todayTestedCount
-                    setupPieChartView(pieChartView: studyPieChartView)
-                    setupPieChartView(pieChartView: testPieChartView)
-                    bringIconToFront()
-                    pieChartAnimation()
-                    setupUI()
+
+                    if isGettedTargetStatus && isGettedActivities {
+                        setupCharts(animate: animate)
+                    }
                 },
                 onError: { [unowned self] in
                     log.error($0.descriptionOfType)
@@ -148,12 +167,16 @@ extension MyPageViewController {
                 }).disposed(by: disposeBag)
     }
 
-    private func fetchActivities() {
+    private func fetchActivities(animate: Bool) {
         viewModel.fetchActivities(authToken: ApplicationConfigData.authToken)
             .subscribe(
                 onNext: { [unowned self] status in
-                    setupBarChartView()
-                    barChartAnimation()
+                    isGettedActivities = true
+                    print("geta")
+
+                    if isGettedTargetStatus && isGettedActivities {
+                        setupCharts(animate: animate)
+                    }
                 },
                 onError: { [unowned self] in
                     log.error($0.descriptionOfType)
@@ -166,6 +189,19 @@ extension MyPageViewController {
         testTargetLabel.text = "TEST " + String(targetTestingCount) + " WORDS"
         studyCurrentCountLabel.text = String(todayLearnedCount)
         testCurrentCountLabel.text = String(todayTestedCount)
+    }
+
+    /// API取得終了後に呼ぶ
+    private func setupCharts(animate: Bool) {
+        setupPieChartView(pieChartView: studyPieChartView)
+        setupPieChartView(pieChartView: testPieChartView)
+        bringIconToFront()
+        setupUI()
+        setupBarChartView()
+        if animate {
+            pieChartAnimation()
+            barChartAnimation()
+        }
     }
 
 }
@@ -269,7 +305,6 @@ extension MyPageViewController {
         pieChartView.rotationEnabled = false // グラフが動くのを無効化
 
         view.addSubview(pieChartView)
-        //pieChartView.animate(xAxisDuration: 1.2, yAxisDuration: 0.8) // アニメーション
     }
 
     /// 円形プロフレスバーの中心のアイコンとラベルを前面に持ってくる

--- a/Japanese_nursing/src/Views/Settings/SettingListViewController.swift
+++ b/Japanese_nursing/src/Views/Settings/SettingListViewController.swift
@@ -35,6 +35,9 @@ class SettingListViewController: UIViewController {
 
     private var disposeBag = DisposeBag()
 
+    private var targetLearningCount = 0
+    private var targetTestingCount = 0
+
     // MARK: - LifeCycles
 
     override func viewDidLoad() {
@@ -57,15 +60,15 @@ class SettingListViewController: UIViewController {
         }).disposed(by: disposeBag)
 
         // 目標学習数タップ
-        studyTargetSettingButton.rx.tap.subscribe(onNext: { [weak self] in
-            let vc = TargetSettingViewController.makeInstance(targetType: .study)
-            self?.navigationController?.pushViewController(vc, animated: true)
+        studyTargetSettingButton.rx.tap.subscribe(onNext: { [unowned self] in
+            let vc = TargetSettingViewController.makeInstance(targetType: .study, initialTargetCount: targetLearningCount)
+            navigationController?.pushViewController(vc, animated: true)
         }).disposed(by: disposeBag)
 
         // 目標テストタップ
-        testTargetSettingButton.rx.tap.subscribe(onNext: { [weak self] in
-            let vc = TargetSettingViewController.makeInstance(targetType: .test)
-            self?.navigationController?.pushViewController(vc, animated: true)
+        testTargetSettingButton.rx.tap.subscribe(onNext: { [unowned self] in
+            let vc = TargetSettingViewController.makeInstance(targetType: .test, initialTargetCount: targetTestingCount)
+            navigationController?.pushViewController(vc, animated: true)
         }).disposed(by: disposeBag)
 
         // 利用規約タップ
@@ -89,16 +92,18 @@ class SettingListViewController: UIViewController {
 
 extension SettingListViewController {
 
-    static func makeInstance() -> UIViewController {
+    static func makeInstance(targetLearningCount: Int, targetTestingCount: Int) -> UIViewController {
         guard let vc = R.storyboard.settingListViewController.settingListViewController() else {
             assertionFailure("Can't make instance 'SettingListViewController'.")
             return UIViewController()
         }
+        vc.targetLearningCount = targetLearningCount
+        vc.targetTestingCount = targetTestingCount
         return vc
     }
 
-    static func makeInstanceInNavigationController() -> UIViewController {
-        return UINavigationController(rootViewController: makeInstance())
+    static func makeInstanceInNavigationController(targetLearningCount: Int, targetTestingCount: Int) -> UIViewController {
+        return UINavigationController(rootViewController: makeInstance(targetLearningCount: targetLearningCount, targetTestingCount: targetTestingCount))
     }
 
 }

--- a/Japanese_nursing/src/Views/Settings/TargetSetting/TargetSettingViewController.swift
+++ b/Japanese_nursing/src/Views/Settings/TargetSetting/TargetSettingViewController.swift
@@ -48,7 +48,7 @@ class TargetSettingViewController: UIViewController, UIPickerViewDelegate, UIPic
     private var disposeBag = DisposeBag()
 
     /// 初期目標値
-    var initialTargetNumber: Int = 30
+    var initialTargetCount: Int = 30
 
     /// ピッカーで選択した目標値
     var selectedTargetNumber: Int = 30
@@ -155,7 +155,7 @@ class TargetSettingViewController: UIViewController, UIPickerViewDelegate, UIPic
         // Delegate設定
         pickerView.delegate = self
         pickerView.dataSource = self
-        setupInitialPickerView()
+
         setupUI(type: targetType)
     }
 
@@ -187,12 +187,14 @@ extension TargetSettingViewController {
 
     /// ピッカーの初期値を設定する
     private func setupInitialPickerView() {
-        let index = pickerDataList.firstIndex(of: initialTargetNumber) ?? 0
+        let index = pickerDataList.firstIndex(of: initialTargetCount) ?? 0
         pickerView.selectRow(index, inComponent: 0, animated: false)
     }
 
     /// 目標タイプによってUIを設定する
     private func setupUI(type: TargetTypeEnum) {
+        setupInitialPickerView()
+        targetNumberLabel.text = String(initialTargetCount)
         topImageView.image = type.topImage
         titleLabel.text = type.title
         targetTypeLabel.text = type.targetString
@@ -207,7 +209,6 @@ extension TargetSettingViewController {
         viewModel.fetch(authToken: ApplicationConfigData.authToken, targetLearningCount: targetLearningCount, targetTestingCount: targetTestingCount)
             .subscribe(
                 onNext: { [unowned self] in
-
                     HUD.flash(.label("保存しました！"), delay: 0.5) {_ in
                         if let nc = self.navigationController {
                             nc.popViewController(animated: true)
@@ -309,22 +310,34 @@ extension TargetSettingViewController {
 
 }
 
+extension TargetSettingViewController {
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)
+        guard let presentationController = presentationController else {
+            return
+        }
+        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
+    }
+    
+}
+
 // MARK: - MakeInstance
 
 extension TargetSettingViewController {
 
-    static func makeInstance(targetType: TargetTypeEnum, initialTargetNumber: Int = 30) -> UIViewController {
+    static func makeInstance(targetType: TargetTypeEnum, initialTargetCount: Int) -> UIViewController {
         guard let vc = R.storyboard.targetSettingViewController.targetSettingViewController() else {
             assertionFailure("Can't make instance 'TargetSettingViewController'.")
             return UIViewController()
         }
         vc.targetType = targetType
-        vc.initialTargetNumber = initialTargetNumber
+        vc.initialTargetCount = initialTargetCount
         return vc
     }
 
-    static func makeInstanceInNavigationController(targetType: TargetTypeEnum, initialTargetNumber: Int = 30) -> UIViewController {
-        let vc = makeInstance(targetType: targetType, initialTargetNumber: initialTargetNumber)
+    static func makeInstanceInNavigationController(targetType: TargetTypeEnum, initialTargetCount: Int) -> UIViewController {
+        let vc = makeInstance(targetType: targetType, initialTargetCount: initialTargetCount)
         return UINavigationController(rootViewController: vc)
     }
 

--- a/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnit.storyboard
+++ b/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnit.storyboard
@@ -26,7 +26,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="45"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.40000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="cuh-In-fzX">
-                                        <rect key="frame" x="60" y="6" width="294" height="33"/>
+                                        <rect key="frame" x="60" y="9.5" width="294" height="26"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKjpSub-Bold" family="NotoSansCJKjpSub-Bold" pointSize="22"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>


### PR DESCRIPTION
# Related issues(関連issues)
close #154 
close #157 

# Overview(概要)
表題のとおり

# Check result(確認項目)
- [x] 目標設定画面のピッカーとラベルに目標値が表示される
- [x] 目標を更新したらマイページの目標値も更新される
