### PR TITLE
新規登録後に単元一覧に遷移すると通信エラーViewが表示される問題の修正

### DIFF
--- a/Japanese_nursing/src/Views/CreateUser/CreateUserViewController.swift
+++ b/Japanese_nursing/src/Views/CreateUser/CreateUserViewController.swift
@@ -115,6 +115,18 @@ class CreateUserViewController: UIViewController {
 
 }
 
+extension CreateUserViewController {
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)
+        guard let presentationController = presentationController else {
+            return
+        }
+        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
+    }
+
+}
+
 // MARK: - MakeInstance
 
 extension CreateUserViewController {


### PR DESCRIPTION
# Related issues(関連issues)
close #135 

# Overview(概要)
表題のとおり

# Check result(確認項目)
- [x] 新規登録後に単元一覧が表示される
