### PR TITLE
学習履歴保存のAPI通信に失敗したときの処理を追加

### DIFF
--- a/Japanese_nursing/src/Models/ApplicationConfigData.swift
+++ b/Japanese_nursing/src/Models/ApplicationConfigData.swift
@@ -14,34 +14,46 @@ class ApplicationConfigData {
 
     private static let ud = UserDefaults.standard
 
-    // ユーザID
+    /// ユーザID
     static var userID: Int {
         get { return self.ud.integer(forKey: "userID")}
         set { self.ud.set(newValue, forKey: "userID")}
     }
 
-    // authToken
+    /// authToken
     static var authToken: String {
         get { return self.ud.string(forKey: "authToken") ?? "" }
         set { self.ud.set(newValue, forKey: "authToken")}
     }
 
-    // role
+    /// role
     static var role: String {
         get { return self.ud.string(forKey: "role") ?? "" }
         set { self.ud.set(newValue, forKey: "role")}
     }
 
-    // ニックネーム
+    /// ニックネーム
     static var userName: String {
         get { return self.ud.string(forKey: "userName") ?? "" }
         set { self.ud.set(newValue, forKey: "userName")}
     }
 
-    // email
+    /// email
     static var email: String {
         get { return self.ud.string(forKey: "email") ?? "" }
         set { self.ud.set(newValue, forKey: "email")}
+    }
+
+    // 未送信の学習履歴
+    /// 覚えた単語
+    static var rememberIdsArray: [String] {
+        get { return self.ud.stringArray(forKey: "rememberIdsArray") ?? [] }
+        set { self.ud.set(newValue, forKey: "rememberIdsArray")}
+    }
+    /// 覚えていない単語
+    static var notRememberIdsArray: [String] {
+        get { return self.ud.stringArray(forKey: "notRememberIdsArray") ?? [] }
+        set { self.ud.set(newValue, forKey: "notRememberIdsArray")}
     }
 
 }

--- a/Japanese_nursing/src/ViewModels/Study/LearningUnitViewModel.swift
+++ b/Japanese_nursing/src/ViewModels/Study/LearningUnitViewModel.swift
@@ -50,13 +50,4 @@ class LearningUnitViewModel {
             })
     }
 
-//    func postLearningHistories(authToken: String, rememberIds: String, notRememberIds: String) -> Observable<Void> {
-//
-//        return PostLearningHistoriesModel().putUser(authToken: authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
-//            .do(onError: {
-//                log.error($0.descriptionOfType)
-//            })
-//            .map { _ in () }
-//    }
-
 }

--- a/Japanese_nursing/src/ViewModels/Study/LearningUnitViewModel.swift
+++ b/Japanese_nursing/src/ViewModels/Study/LearningUnitViewModel.swift
@@ -50,13 +50,13 @@ class LearningUnitViewModel {
             })
     }
 
-    func postLearningHistories(authToken: String, rememberIds: String, notRememberIds: String) -> Observable<Void> {
-
-        return PostLearningHistoriesModel().putUser(authToken: authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
-            .do(onError: {
-                log.error($0.descriptionOfType)
-            })
-            .map { _ in () }
-    }
+//    func postLearningHistories(authToken: String, rememberIds: String, notRememberIds: String) -> Observable<Void> {
+//
+//        return PostLearningHistoriesModel().putUser(authToken: authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
+//            .do(onError: {
+//                log.error($0.descriptionOfType)
+//            })
+//            .map { _ in () }
+//    }
 
 }

--- a/Japanese_nursing/src/ViewModels/Study/UnitListViewModel.swift
+++ b/Japanese_nursing/src/ViewModels/Study/UnitListViewModel.swift
@@ -60,4 +60,13 @@ class UnitListViewModel {
             })
     }
 
+    func postLearningHistories(authToken: String, rememberIds: String, notRememberIds: String) -> Observable<Void> {
+
+        return PostLearningHistoriesModel().putUser(authToken: authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
+            .do(onError: {
+                log.error($0.descriptionOfType)
+            })
+            .map { _ in () }
+    }
+
 }

--- a/Japanese_nursing/src/ViewModels/Study/UnitListViewModel.swift
+++ b/Japanese_nursing/src/ViewModels/Study/UnitListViewModel.swift
@@ -60,13 +60,26 @@ class UnitListViewModel {
             })
     }
 
-    func postLearningHistories(authToken: String, rememberIds: String, notRememberIds: String) -> Observable<Void> {
+    /// 学習履歴を更新する
+    func postLearningHistories() -> Observable<Void> {
 
-        return PostLearningHistoriesModel().putUser(authToken: authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
+        let rememberIds = arrayToString(array: ApplicationConfigData.rememberIdsArray)
+        let notRememberIds = arrayToString(array: ApplicationConfigData.notRememberIdsArray)
+
+        return PostLearningHistoriesModel().putUser(authToken: ApplicationConfigData.authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
             .do(onError: {
                 log.error($0.descriptionOfType)
             })
             .map { _ in () }
+    }
+
+    /// 配列を文字列に変換する(学習履歴のPostで使用)
+    private func arrayToString(array: [String]) -> String {
+        var str = ""
+        for i in array {
+            str = str + "," + i
+        }
+        return String(str.dropFirst(1))
     }
 
 }

--- a/Japanese_nursing/src/Views/Mypage/MyPageViewController.swift
+++ b/Japanese_nursing/src/Views/Mypage/MyPageViewController.swift
@@ -93,6 +93,9 @@ class MyPageViewController: UIViewController {
 
         pieChartAnimation()
         barChartAnimation()
+        fetchTargetStatus(animate: false)
+        fetchActivities(animate: false)
+
     }
 
     // 遷移先の画面が閉じられた時に呼ばれる

--- a/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
+++ b/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
@@ -35,10 +35,6 @@ class LearningUnitViewController: UIViewController {
 
     // MARK: - Properties
 
-//    private var rememberIdsArray: [Int] = []
-//
-//    private var notRememberIdsArray: [Int] = []
-
     private let kolodaView = KolodaView()
 
     private var unitTitle = ""
@@ -98,7 +94,6 @@ class LearningUnitViewController: UIViewController {
     private func subscribe() {
         // 閉じるボタンタップ
         closeButton.rx.tap.subscribe(onNext: { [weak self] in
-//            self?.postLearningHistories()
             self?.dismiss(animated: true)
         }).disposed(by: disposeBag)
 
@@ -142,37 +137,6 @@ class LearningUnitViewController: UIViewController {
                 }).disposed(by: disposeBag)
     }
 
-//    /// 配列を文字列に変換する(学習履歴のPostで使用)
-//    private func arrayToString(array: [Int]) -> String {
-//        var str = ""
-//        for i in array {
-//            str = str + "," + String(i)
-//        }
-//        return String(str.dropFirst(1))
-//    }
-
-    /// 学習履歴を更新
-//    private func postLearningHistories() {
-//        let rememberIds = arrayToString(array: rememberIdsArray)
-//        let notRememberIds = arrayToString(array: notRememberIdsArray)
-//
-//        HUD.show(.progress)
-//        viewModel.postLearningHistories(authToken: ApplicationConfigData.authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
-//            .subscribe(
-//                onNext: { [unowned self] _ in
-//                    HUD.hide()
-//                    dismiss(animated: true)
-//                },
-//                onError: { [unowned self] _ in
-//                    HUD.hide()
-//                    // 次回単元一覧表示時に再送信するため、UserDefaultsに追加
-//                    ApplicationConfigData.rememberIdsArray.append(rememberIdsArray)
-//                    ApplicationConfigData.notRememberIdsArray.append(notRememberIdsArray)
-//                    dismiss(animated: true)
-//                }
-//            ).disposed(by: disposeBag)
-//    }
-
     /// 進捗バーを更新する
     private func updateProgressView(swipedCardIndex: Int) {
         /// カードの最大枚数
@@ -206,10 +170,8 @@ extension LearningUnitViewController: KolodaViewDelegate {
     func koloda(_ koloda: KolodaView, didSwipeCardAt index: Int, in direction: SwipeResultDirection) {
         switch direction {
         case .right:
-//            rememberIdsArray.append(viewModel.words[index].id)
             ApplicationConfigData.rememberIdsArray.append(String(viewModel.words[index].id))
         case .left:
-//            notRememberIdsArray.append(viewModel.words[index].id)
             ApplicationConfigData.notRememberIdsArray.append(String(viewModel.words[index].id))
         default:
             break
@@ -231,7 +193,6 @@ extension LearningUnitViewController: KolodaViewDelegate {
                 self?.progressView.setProgress(0, animated: true)
             }
             alertView.addButton("終了する") { [weak self] in
-//                self?.postLearningHistories()
                 self?.dismiss(animated: true)
             }
 

--- a/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
+++ b/Japanese_nursing/src/Views/Study/LearningUnit/LearningUnitViewController.swift
@@ -11,6 +11,7 @@ import Koloda
 import RxSwift
 import RxCocoa
 import SCLAlertView
+import PKHUD
 
 /**
  * 学習画面VC
@@ -34,9 +35,9 @@ class LearningUnitViewController: UIViewController {
 
     // MARK: - Properties
 
-    private var rememberIdsArray: [Int] = []
-
-    private var notRememberIdsArray: [Int] = []
+//    private var rememberIdsArray: [Int] = []
+//
+//    private var notRememberIdsArray: [Int] = []
 
     private let kolodaView = KolodaView()
 
@@ -97,7 +98,7 @@ class LearningUnitViewController: UIViewController {
     private func subscribe() {
         // 閉じるボタンタップ
         closeButton.rx.tap.subscribe(onNext: { [weak self] in
-            self?.postLearningHistories()
+//            self?.postLearningHistories()
             self?.dismiss(animated: true)
         }).disposed(by: disposeBag)
 
@@ -141,27 +142,36 @@ class LearningUnitViewController: UIViewController {
                 }).disposed(by: disposeBag)
     }
 
-    /// 配列を文字列に変換する(学習履歴のPostで使用)
-    private func arrayToString(array: [Int]) -> String {
-        var str = ""
-        for i in array {
-            str = str + "," + String(i)
-        }
-        return String(str.dropFirst(1))
-    }
+//    /// 配列を文字列に変換する(学習履歴のPostで使用)
+//    private func arrayToString(array: [Int]) -> String {
+//        var str = ""
+//        for i in array {
+//            str = str + "," + String(i)
+//        }
+//        return String(str.dropFirst(1))
+//    }
 
     /// 学習履歴を更新
-    private func postLearningHistories() {
-        let rememberIds = arrayToString(array: rememberIdsArray)
-        let notRememberIds = arrayToString(array: notRememberIdsArray)
-
-        viewModel.postLearningHistories(authToken: ApplicationConfigData.authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
-            .subscribe(
-                onError: { _ in
-                    // TODO: - エラー時の処理を追加する
-                }
-            ).disposed(by: disposeBag)
-    }
+//    private func postLearningHistories() {
+//        let rememberIds = arrayToString(array: rememberIdsArray)
+//        let notRememberIds = arrayToString(array: notRememberIdsArray)
+//
+//        HUD.show(.progress)
+//        viewModel.postLearningHistories(authToken: ApplicationConfigData.authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
+//            .subscribe(
+//                onNext: { [unowned self] _ in
+//                    HUD.hide()
+//                    dismiss(animated: true)
+//                },
+//                onError: { [unowned self] _ in
+//                    HUD.hide()
+//                    // 次回単元一覧表示時に再送信するため、UserDefaultsに追加
+//                    ApplicationConfigData.rememberIdsArray.append(rememberIdsArray)
+//                    ApplicationConfigData.notRememberIdsArray.append(notRememberIdsArray)
+//                    dismiss(animated: true)
+//                }
+//            ).disposed(by: disposeBag)
+//    }
 
     /// 進捗バーを更新する
     private func updateProgressView(swipedCardIndex: Int) {
@@ -196,9 +206,11 @@ extension LearningUnitViewController: KolodaViewDelegate {
     func koloda(_ koloda: KolodaView, didSwipeCardAt index: Int, in direction: SwipeResultDirection) {
         switch direction {
         case .right:
-            rememberIdsArray.append(viewModel.words[index].id)
+//            rememberIdsArray.append(viewModel.words[index].id)
+            ApplicationConfigData.rememberIdsArray.append(String(viewModel.words[index].id))
         case .left:
-            notRememberIdsArray.append(viewModel.words[index].id)
+//            notRememberIdsArray.append(viewModel.words[index].id)
+            ApplicationConfigData.notRememberIdsArray.append(String(viewModel.words[index].id))
         default:
             break
         }
@@ -219,7 +231,7 @@ extension LearningUnitViewController: KolodaViewDelegate {
                 self?.progressView.setProgress(0, animated: true)
             }
             alertView.addButton("終了する") { [weak self] in
-                self?.postLearningHistories()
+//                self?.postLearningHistories()
                 self?.dismiss(animated: true)
             }
 

--- a/Japanese_nursing/src/Views/Study/UnitList/UnitListViewController.swift
+++ b/Japanese_nursing/src/Views/Study/UnitList/UnitListViewController.swift
@@ -77,12 +77,6 @@ class UnitListViewController: UIViewController, UIScrollViewDelegate, UIAdaptive
 
     }
 
-    // 遷移先の画面が閉じられた時に呼ばれる
-    // これも必要なくなるはず
-//    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-//        fetch()
-//    }
-
 }
 
 // MARK: - Functions
@@ -135,22 +129,10 @@ extension UnitListViewController {
                 }).disposed(by: disposeBag)
     }
 
-    /// 配列を文字列に変換する(学習履歴のPostで使用)
-    // VMでやりたい
-    private func arrayToString(array: [String]) -> String {
-        var str = ""
-        for i in array {
-            str = str + "," + i
-        }
-        return String(str.dropFirst(1))
-    }
-
     /// 学習履歴を更新
     private func postLearningHistories() {
-        let rememberIds = arrayToString(array: ApplicationConfigData.rememberIdsArray)
-        let notRememberIds = arrayToString(array: ApplicationConfigData.notRememberIdsArray)
-
-        viewModel.postLearningHistories(authToken: ApplicationConfigData.authToken, rememberIds: rememberIds, notRememberIds: notRememberIds)
+        
+        viewModel.postLearningHistories()
             .subscribe(
                 onNext: { [unowned self] _ in
                     // 学習履歴の更新に成功した場合、UserDefaultsを初期化する
@@ -173,7 +155,7 @@ extension UnitListViewController {
         let dataSource = RxTableViewSectionedReloadDataSource<UnitListSectionDomainModel>(configureCell: { (_, tableView, indexPath, item) in
             guard let cell = tableView.dequeueReusableCell(withIdentifier: R.reuseIdentifier.unitListCell.identifier, for: indexPath) as?
                     UnitListCell else {
-                log.error("Can't cast R.reuseIdentifier.unitListCell to UnitLIstCell")
+                log.error("Can't cast R.reuseIdentifier.unitListCell to UnitListCell")
                 return UITableViewCell()
             }
 


### PR DESCRIPTION
# Related issues(関連issues)
close #160 

# Overview(概要)
表題のとおり

# Check result(確認項目)
- [x] 学習履歴の更新に失敗した場合、次に単元一覧を開いた時に通信が行われる
