### PR TITLE
単元一覧で習得バッジとラベルの表示をかぶらないようにする

### DIFF
--- a/Japanese_nursing/src/Views/Study/UnitList/UnitList.storyboard
+++ b/Japanese_nursing/src/Views/Study/UnitList/UnitList.storyboard
@@ -49,7 +49,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="45"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LEARN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c8A-YL-pi1">
-                                        <rect key="frame" x="171.5" y="9.5" width="71" height="26"/>
+                                        <rect key="frame" x="171" y="6" width="72" height="33"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKjpSub-Bold" family="NotoSansCJKjpSub-Bold" pointSize="22"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
@@ -81,16 +81,16 @@
                                                     <rect key="frame" x="10" y="2" width="394" height="94"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="51D-DH-Y6B">
-                                                            <rect key="frame" x="10" y="10" width="374" height="74"/>
+                                                            <rect key="frame" x="10" y="10" width="330" height="74"/>
                                                             <subviews>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="RAV-xT-QaQ">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="374" height="74"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="330" height="74"/>
                                                                     <subviews>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jd1-dy-rrG">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="374" height="24.5"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="330" height="24.5"/>
                                                                             <subviews>
                                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X5D-wA-Zka">
-                                                                                    <rect key="frame" x="8" y="7" width="22.5" height="10.5"/>
+                                                                                    <rect key="frame" x="8" y="5.5" width="24" height="13.5"/>
                                                                                     <fontDescription key="fontDescription" name="NotoSansCJKjpSub-Medium" family="NotoSansCJKjpSub-Medium" pointSize="9"/>
                                                                                     <color key="textColor" name="WeakText"/>
                                                                                     <nil key="highlightedColor"/>
@@ -103,10 +103,10 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5OY-t3-u4A">
-                                                                            <rect key="frame" x="0.0" y="24.5" width="374" height="25"/>
+                                                                            <rect key="frame" x="0.0" y="24.5" width="330" height="25"/>
                                                                             <subviews>
-                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pi6-Xv-FDX">
-                                                                                    <rect key="frame" x="8" y="2" width="33" height="21"/>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="pi6-Xv-FDX">
+                                                                                    <rect key="frame" x="8" y="-1" width="322" height="27"/>
                                                                                     <fontDescription key="fontDescription" name="NotoSansCJKjpSub-Medium" family="NotoSansCJKjpSub-Medium" pointSize="18"/>
                                                                                     <color key="textColor" name="TextDarkGray"/>
                                                                                     <nil key="highlightedColor"/>
@@ -115,12 +115,13 @@
                                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="height" constant="30" id="AkI-8Z-OrQ"/>
+                                                                                <constraint firstAttribute="trailing" secondItem="pi6-Xv-FDX" secondAttribute="trailing" id="XYc-VF-Upd"/>
                                                                                 <constraint firstItem="pi6-Xv-FDX" firstAttribute="centerY" secondItem="5OY-t3-u4A" secondAttribute="centerY" id="Ys5-Ai-f7u"/>
                                                                                 <constraint firstItem="pi6-Xv-FDX" firstAttribute="leading" secondItem="5OY-t3-u4A" secondAttribute="leading" constant="8" id="gVk-ge-4ab"/>
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kcm-8g-ZAj">
-                                                                            <rect key="frame" x="0.0" y="49.5" width="374" height="24.5"/>
+                                                                            <rect key="frame" x="0.0" y="49.5" width="330" height="24.5"/>
                                                                             <subviews>
                                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="word_gray" translatesAutoresizingMaskIntoConstraints="NO" id="fw7-kt-uhD">
                                                                                     <rect key="frame" x="8" y="9.5" width="13" height="13"/>
@@ -190,7 +191,7 @@
                                                     <constraints>
                                                         <constraint firstAttribute="trailing" secondItem="WQz-Ud-FNL" secondAttribute="trailing" constant="18" id="NDs-gE-xhF"/>
                                                         <constraint firstAttribute="bottom" secondItem="51D-DH-Y6B" secondAttribute="bottom" constant="10" id="UaR-LB-MSe"/>
-                                                        <constraint firstAttribute="trailing" secondItem="51D-DH-Y6B" secondAttribute="trailing" constant="10" id="lVJ-m2-FjR"/>
+                                                        <constraint firstItem="WQz-Ud-FNL" firstAttribute="leading" secondItem="51D-DH-Y6B" secondAttribute="trailing" constant="10" id="rtK-6T-VlY"/>
                                                         <constraint firstItem="51D-DH-Y6B" firstAttribute="leading" secondItem="CUP-8P-ajf" secondAttribute="leading" constant="10" id="vfd-0x-BD7"/>
                                                         <constraint firstItem="51D-DH-Y6B" firstAttribute="top" secondItem="CUP-8P-ajf" secondAttribute="top" constant="10" id="y7J-df-5gg"/>
                                                         <constraint firstItem="WQz-Ud-FNL" firstAttribute="centerY" secondItem="CUP-8P-ajf" secondAttribute="centerY" id="z5Q-nY-DrG"/>


### PR DESCRIPTION
# Related issues(関連issues)
close #172 

# Overview(概要)
表題のとおり

# Check result(確認項目)
- [ ] 習得バッジとラベルの表示がかぶらない
